### PR TITLE
refactor: move fonts definitions to a separate package

### DIFF
--- a/aneotheme/aneotheme.sty
+++ b/aneotheme/aneotheme.sty
@@ -3,40 +3,7 @@
 \RequirePackage{tikz}
 \usetikzlibrary{calc}
 \RequirePackage{graphicx}
-
-\usepackage{fontspec}
-
-\newfontfamily{\poppinsfont}{Poppins}[
-    Extension = .ttf,
-    UprightFont = *-Light,
-    BoldFont = *-SemiBold,
-    ItalicFont = *-LightItalic,
-    BoldItalicFont = *-SemiBoldItalic
-]
-
-\newfontfamily{\poppinsboldfont}{Poppins}[
-    Extension = .ttf,
-    UprightFont = *-Bold,
-    BoldFont = *-Black,
-    ItalicFont = *-BoldItalic,
-    BoldItalicFont = *-BlackItalic
-]
-
-\setmainfont{Poppins}[
-    Extension = .ttf,
-    UprightFont = *-Light,
-    BoldFont = *-SemiBold,
-    ItalicFont = *-LightItalic,
-    BoldItalicFont = *-SemiBoldItalic
-]
-
-%\setmainfont{LexendDeca}[
-%    Extension = .ttf,
-%    UprightFont = *-Light,
-%    BoldFont = *-SemiBold,
-%    ItalicFont = *-LightItalic,
-%    BoldItalicFont = *-SemiBoldItalic
-%]
+\RequirePackage{poppinsfonts}
 
 % Set titles and subtitles in Poppins Semibold as
 % in the charte graphique from 2024

--- a/aneotheme/poppinsfonts.sty
+++ b/aneotheme/poppinsfonts.sty
@@ -1,0 +1,27 @@
+\ProvidesPackage{poppinsfonts}
+
+\RequirePackage{fontspec}
+
+\newfontfamily{\poppinsfont}{Poppins}[
+    Extension = .ttf,
+    UprightFont = *-Light,
+    BoldFont = *-SemiBold,
+    ItalicFont = *-LightItalic,
+    BoldItalicFont = *-SemiBoldItalic
+]
+
+\newfontfamily{\poppinsboldfont}{Poppins}[
+    Extension = .ttf,
+    UprightFont = *-Bold,
+    BoldFont = *-Black,
+    ItalicFont = *-BoldItalic,
+    BoldItalicFont = *-BlackItalic
+]
+
+\setmainfont{Poppins}[
+    Extension = .ttf,
+    UprightFont = *-Light,
+    BoldFont = *-SemiBold,
+    ItalicFont = *-LightItalic,
+    BoldItalicFont = *-SemiBoldItalic
+]


### PR DESCRIPTION
Separate fonts definitions from the beamer theme so they can be used to compile standalone images